### PR TITLE
Amplify linear velocity to help throwing objects

### DIFF
--- a/src/openvr_plugin/driver_psmoveservice.h
+++ b/src/openvr_plugin/driver_psmoveservice.h
@@ -340,6 +340,10 @@ private:
 	// Treat a thumbstick touch also as a press
 	bool m_bThumbstickTouchAsPress;
 
+	// Settings values. Used to adjust throwing power using linear velocity and acceleration.
+	float m_fLinearVelocityMultiplier;
+	float m_fLinearVelocityExponent;
+
     // Callbacks
     static void start_controller_response_callback(const PSMResponseMessage *response, void *userdata);
 };


### PR DESCRIPTION
Added a multiplier and an exponent option to steamvr.vrsettings for the
linear velocity to improve the "throwing power". The default values make it
behave as if there were no change.

The acceleration wasn't similarly modified because it didn't seem necessary.