### PR TITLE
Added the option to rotate how the PSMove is held

### DIFF
--- a/src/openvr_plugin/driver_psmoveservice.h
+++ b/src/openvr_plugin/driver_psmoveservice.h
@@ -279,6 +279,9 @@ private:
 	float m_fVirtuallExtendControllersYMeters;
 	float m_fVirtuallExtendControllersZMeters;
 
+	// virtually rotate controller
+	bool m_fVirtuallyRotateController;
+
 	// delay in resetting touchpad position after touchpad press
 	bool m_bDelayAfterTouchpadPress;
 


### PR DESCRIPTION
This option is intended for when a PSNavi is attached to the PSMove
controller so that it can be done with the two triggers facing each
other. This changes the HMD alignment pose to bulb down and trigger
forward.

To enable this rotated mode set "psmove_rotate": true under
"psmove_settings" in steamvr.vrsettings.