### PR TITLE
Trigger axis configuration for oculus touch emulation

### DIFF
--- a/src/openvr_plugin/driver_psmoveservice.h
+++ b/src/openvr_plugin/driver_psmoveservice.h
@@ -336,6 +336,7 @@ private:
 
 	// The axis to use for trigger input
 	int m_triggerAxisIndex;
+	int m_navitriggerAxisIndex;
 
 	// The size of the deadzone for the controller's thumbstick
 	float m_thumbstickDeadzone;


### PR DESCRIPTION
This is for when Unity games think the controllers are oculus touch instead of vive controllers. Setting  "trigger_axis_index" under "psnavi_button" will specify which trigger axis the PSNavi actuates so that two real triggers can be used. If instead only the PSMove is to be use then assigning a button to "trigger"  will now actuate axis 1.