### PR TITLE
Fix for full battery indication

### DIFF
--- a/src/openvr_plugin/driver_psmoveservice.cpp
+++ b/src/openvr_plugin/driver_psmoveservice.cpp
@@ -1366,7 +1366,7 @@ CPSMoveControllerLatest::CPSMoveControllerLatest(
     , m_PSMChildControllerView(nullptr)
     , m_nPoseSequenceNumber(0)
     , m_bIsBatteryCharging(false)
-    , m_fBatteryChargeFraction(1.f)
+    , m_fBatteryChargeFraction(0.f)
 	, m_bRumbleSuppressed(false)
     , m_pendingHapticPulseDuration(0)
     , m_lastTimeRumbleSent()


### PR DESCRIPTION
The battery information is only updated when the level changes but the
starting value was originally 1. This meant that if the battery was full
at the start then the battery information was not sent to SteamVR. To
fix this the initial value has been set to 0.